### PR TITLE
Pass index of selected row to handler

### DIFF
--- a/src/RowSelect.js
+++ b/src/RowSelect.js
@@ -48,9 +48,9 @@ module.exports = {
         return index
     },
 
-    notifySelection: function(selected, data){
+    notifySelection: function(selected, data, index){
         if (typeof this.props.onSelectionChange == 'function'){
-            this.props.onSelectionChange(selected, data)
+            this.props.onSelectionChange(selected, data, index)
         }
 
         if (!hasOwn(this.props, 'selected')){
@@ -61,7 +61,7 @@ module.exports = {
         }
     },
 
-    handleSingleSelection: function(data, event){
+    handleSingleSelection: function(data, event, index){
         var props = this.p
 
         var rowSelected = this.isRowSelected(data)
@@ -77,7 +77,7 @@ module.exports = {
                             data[props.idProperty]:
                             null
 
-        this.notifySelection(selectedId, data)
+        this.notifySelection(selectedId, data, index)
     },
 
 
@@ -112,7 +112,7 @@ module.exports = {
             }
         })
 
-        this.notifySelection(map, data)
+        this.notifySelection(map, data, selIndex)
     },
 
     handleMultiSelectionRowToggle: function(data, event){
@@ -129,7 +129,7 @@ module.exports = {
             clone[id] = data
         }
 
-        this.notifySelection(clone, data)
+        this.notifySelection(clone, data, event)
 
         return isSelected
     },
@@ -146,7 +146,7 @@ module.exports = {
         var multiSelect = this.isMultiSelect()
 
         if (!multiSelect){
-            this.handleSingleSelection(rowProps.data, event)
+            this.handleSingleSelection(rowProps.data, event, rowProps.index)
             return
         }
 


### PR DESCRIPTION
I'm attempting to apply an overly effect on top of a row when it's selected.  To do so I need to know what it's position should be,  which is easily calculated if we have the row index since we know the row heights.

Of course this could be calculated by searching through each row of data and looking the matching id, but that's pretty expensive and doesn't really need to be done since the grid already knows the index.

In my opinion the first argument, `selectedId` to `onSelectionChange` is useless, since that information is also contained in the second `data` argument.  I think it'd make more sense to pass the `index` as the first argument, instead of the `selectedId`.  I didn't do so here because I was hesitant to break api compatibility.  If you're in agreement on this, I'll be happy to rework to do so.


