### PR TITLE
set mouse up/down events explicitly on headers, fixes #98

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -56,7 +56,7 @@ var columns = [
 
 var ROW_HEIGHT = 31
 var LEN = 2000
-var SORT_INFO = []//[ { name: 'id', dir: 'asc'} ]
+var SORT_INFO = [{name: 'country', dir: 'asc'}]//[ { name: 'id', dir: 'asc'} ]
 var sort = sorty(SORT_INFO)
 var data = gen(LEN);
 
@@ -70,10 +70,17 @@ var App = React.createClass({
             ref="dataGrid"
             idProperty='id'
             dataSource={data}
+            sortInfo={SORT_INFO}
+            onSortChange={this.handleSortChange}
             columns={columns}
             style={{height: 400}}
             onColumnResize={this.onColumnResize}
         />
+    },
+    handleSortChange: function(sortInfo){
+        SORT_INFO = sortInfo
+        data = sort(data)
+        this.setState({})
     }
 })
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "hasown": "^1.0.1",
     "normalize.css": "^3.0.3",
     "object-assign": "^2.0.0",
-    "react-event-names": "^1.0.0",
     "react-load-mask": "^1.0.1",
     "react-menus": "^1.1.1",
     "react-simple-toolbar": "^1.0.5",

--- a/src/Cell/index.jsx
+++ b/src/Cell/index.jsx
@@ -4,8 +4,6 @@ var React  = require('react')
 var assign = require('object-assign')
 var normalize = require('react-style-normalizer')
 
-var EVENT_NAMES = require('react-event-names')
-
 var TEXT_ALIGN_2_JUSTIFY = {
     right : 'flex-end',
     center: 'center'

--- a/src/Header/index.jsx
+++ b/src/Header/index.jsx
@@ -13,7 +13,6 @@ var setupColumnDrag   = require('./setupColumnDrag')
 var setupColumnResize = require('./setupColumnResize')
 
 var normalize   = require('react-style-normalizer')
-var EVENT_NAMES = require('react-event-names')
 
 function emptyFn(){}
 
@@ -227,8 +226,8 @@ module.exports = React.createClass({
 
         var events = {}
 
-        events[EVENT_NAMES.onMouseDown] = this.handleMouseDown.bind(this, column)
-        events[EVENT_NAMES.onMouseUp] = this.handleMouseUp.bind(this, column)
+        events.onMouseDown = this.handleMouseDown.bind(this, column)
+        events.onMouseUp = this.handleMouseUp.bind(this, column)
 
         return (
             <Cell


### PR DESCRIPTION
on chrome sometimes EVENT_NAMES.onMouseDown is set to onTouchDown
on devices that have a mouse, this means that columns don't handle
clicks, only touch events, here we set the event name explicitly
so it handles both.