### PR TITLE
Allow selection of row 0

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -25,7 +25,7 @@ var gen = (function(){
 
         for (var i = 0; i < len; i++){
             arr.push({
-                id       : i + 1,
+                id       : i,
                 // id: Guid.create(),
                 grade      : Math.round(Math.random() * 10),
                 email    : faker.internet.email(),
@@ -60,16 +60,29 @@ var SORT_INFO = [{name: 'country', dir: 'asc'}]//[ { name: 'id', dir: 'asc'} ]
 var sort = sorty(SORT_INFO)
 var data = gen(LEN);
 
+var SELECTED_ID = data[5].id
+var name = data[5].firstName
+
 class App extends React.Component {
     constructor(props, context) {
         super(props, context);
         this.handleSortChange = this.handleSortChange.bind(this);
         this.onColumnResize = this.onColumnResize.bind(this);
+        this.onSelectionChange = this.onSelectionChange.bind(this);
     }
 
     onColumnResize(firstCol, firstSize, secondCol, secondSize) {
         firstCol.width = firstSize
         this.setState({})
+    }
+
+    onSelectionChange(newSelectedId, data){
+      SELECTED_ID = newSelectedId
+
+      name = SELECTED_ID != null? data.firstName: 'none'
+
+      console.log(SELECTED_ID)
+      this.setState({})
     }
 
     render() {
@@ -82,6 +95,8 @@ class App extends React.Component {
             columns={columns}
             style={{height: 400}}
             onColumnResize={this.onColumnResize}
+            selected={SELECTED_ID}
+            onSelectionChange={this.onSelectionChange}
         />
     }
 
@@ -90,6 +105,8 @@ class App extends React.Component {
         data = sort(data)
         this.setState({})
     }
+
+
 }
 
 ReactDOM.render((

--- a/src/render/renderRow.jsx
+++ b/src/render/renderRow.jsx
@@ -34,9 +34,9 @@ module.exports = function renderRow(props, data, index, fn){
 
     var selected = false
 
-    if (typeof props.selected == 'object' && props.selected){
+    if (typeof props.selected == 'object' && props.selected != null){
         selected = !!props.selected[selectedKey]
-    } else if (props.selected){
+    } else if (props.selected != null){
         selected = selectedKey === props.selected
     }
 


### PR DESCRIPTION
We encountered an issue with the row selection feature. Our indexes start at 0, not at 1. Unfortunately it was not possible to select row 0, since 0 was evaluated to `false` in `renderRow.jsx`. You can see it, if you start the id-counter at 0 instead of starting at 1 as in the example.
IMHO, only my `renderRow.jsx` change has to be merged for this.