### PR TITLE
Prevent warning "unknown props" in React 15

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "stage-0", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.2",
     "babel-preset-react": "^6.1.2",
+    "babel-preset-stage-0": "^6.16.0",
     "css-loader": "^0.9.0",
     "exports-loader": "^0.6.2",
     "extract-text-webpack-plugin": "^0.8.2",

--- a/src/Cell/index.jsx
+++ b/src/Cell/index.jsx
@@ -116,10 +116,10 @@ var Cell = React.createClass({
     render: function(){
         var props = this.p = this.prepareProps(this.props)
 
-        var column    = props.column
-        var textAlign = column && column.textAlign
-        var text      = props.renderText?
-            props.renderText(props.text, column, props.rowIndex):
+        var propsColumn    = props.column
+        var textAlign = propsColumn && propsColumn.textAlign
+        var propsText      = props.renderText?
+            props.renderText(props.text, propsColumn, props.rowIndex):
             props.text
 
         var contentProps = {
@@ -130,15 +130,19 @@ var Cell = React.createClass({
         }
 
         var content = props.renderCell?
-                            props.renderCell(contentProps, text, props):
-                            React.DOM.div(contentProps, text)
+                            props.renderCell(contentProps, propsText, props):
+                            React.DOM.div(contentProps, propsText)
 
         var renderProps = assign({}, props)
 
         delete renderProps.data
 
+        const {contentPadding, columns, index, column, text, header,
+          firstClassName, lastClassName, defaultStyle, rowIndex, textPadding, renderCell,
+          renderText, ...rest} = renderProps
+
         return (
-            <div {...renderProps}>
+            <div {...rest}>
                 {content}
                 {props.children}
             </div>

--- a/src/Row/index.jsx
+++ b/src/Row/index.jsx
@@ -37,7 +37,10 @@ module.exports = React.createClass({
     var cells = props.children || props.columns
             .map(this.renderCell.bind(this, this.props))
 
-    return <div {...props}>{cells}</div>
+    const {cellFactory, renderCell, renderText, rowHeight, minWidth,
+      rowContextMenu, showMenu, _onClick, selectable, index, columns, defaultStyle, ...rest} = props
+
+    return <div {...rest}>{cells}</div>
   },
 
   prepareProps: function(thisProps){


### PR DESCRIPTION
I would like to add another PR to adress #231 since #250 crashes some DataGrid features such as filtering and sorting. In my PR I am using the rest operator to exlude the unwanted props before passing them down. Thus, be aware of the `stage-0` in the .babelrc file as well as the additional babel dependency.

Additional note: Unfortunately I was not able to fix the warnings in the react-virtual-scroller and react-load-mask since these repos are not available anymore (#260). But you can fix these warnings, if you dont' use the LoadMask like this:

```
// TODO: Fix warning: Unknown props 'visible', 'visibile', 'theme' on <div> tag in react-load-mask.
/*
if (props.loadMaskOverHeader){
  loadMask = <LoadMask visible={props.loading} />
}
*/
```

It would be really nice, if some of the project maintainers could give some information about the scroller and the load-mask repo...
